### PR TITLE
Fixes to the rpm spec and setup script

### DIFF
--- a/org.cockpit-project.cockpit-ceph-installer.metainfo.xml
+++ b/org.cockpit-project.cockpit-ceph-installer.metainfo.xml
@@ -1,0 +1,15 @@
+<component type="addon">
+  <id>org.cockpit-project.cockpit-ceph-installer</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Ceph Installer Plugin</name>
+  <summary>
+    Scaffolding for a cockpit module.
+  </summary>
+  <description>
+    <p>
+      Scaffolding for a cockpit module.
+    </p>
+  </description>
+  <extends>cockpit.desktop</extends>
+  <launchable type="cockpit-manifest">cockpit-ceph-installer</launchable>
+</component>


### PR DESCRIPTION
The rpm spec was still configured for the older
standalone ansible-runner-service, with redundant
requires and additional post install steps. These
have been removed and docker/podman support
has been added based on the dist macro.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>