### PR TITLE
Spec file fix

### DIFF
--- a/cockpit-ceph-installer.spec
+++ b/cockpit-ceph-installer.spec
@@ -11,7 +11,7 @@ Requires: ceph-ansible >= 3.1
 Requires: cockpit 
 Requires: cockpit-bridge
 
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{rhel}" == "7"
 %define containermgr    docker
 %else
 %define containermgr    podman


### PR DESCRIPTION
Redhat packaging uses a suffix (cp) which resulted
in the wrong Requires for docker/podman

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>