### PR TITLE
podman-docker: Select the right container manager

### DIFF
--- a/utils/ansible-runner-service.sh
+++ b/utils/ansible-runner-service.sh
@@ -17,6 +17,17 @@ CONTAINER_BIN=''
 CONTAINER_RUN_OPTIONS=''
 
 set_container_bin() {
+
+    os_id=$(awk -F '=' '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
+    version_id=$(awk -F '=' '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '.' | tr -d '"')
+    if [ $os_id == "rhel" ]; then
+            if [ $version_id -ge "80" ]; then
+                  CONTAINER_OPTS="podman"
+            else
+                  CONTAINER_OPTS="docker"
+            fi
+    fi
+
     for option in ${CONTAINER_OPTS[@]}; do
         type $option > /dev/null 2>&1
         if [ $? -eq 0 ]; then

--- a/utils/ansible-runner-service.sh
+++ b/utils/ansible-runner-service.sh
@@ -5,7 +5,7 @@
 # Cert identity and password may be overridden by environment variables - see help
 
 VERBOSE=false
-CONTAINER_OPTS="docker podman"
+CONTAINER_OPTS="podman docker"
 PREREQS="openssl curl"
 ETCDIR="/etc/ansible-runner-service"
 SERVERCERTS="$ETCDIR/certs/server"
@@ -18,20 +18,25 @@ CONTAINER_RUN_OPTIONS=''
 
 set_container_bin() {
     for option in ${CONTAINER_OPTS[@]}; do
-            type $option > /dev/null 2>&1
-            if [ $? -eq 0 ]; then
-                if $VERBOSE; then
-                    echo -e "\tOptional binary $option is present"
-                fi
-                CONTAINER_BIN=$option
-                if [ $CONTAINER_BIN == "docker" ]; then
-                    CONTAINER_RUN_OPTIONS=' --rm -d '
-                else
-                    CONTAINER_RUN_OPTIONS=' -d '
-                fi
-                break
+        type $option > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            if $VERBOSE; then
+                echo -e "\tOptional binary $option is present"
             fi
-        done
+            CONTAINER_BIN=$option
+            if [ $CONTAINER_BIN == "docker" ]; then
+                CONTAINER_RUN_OPTIONS=' --rm -d '
+            else
+                CONTAINER_RUN_OPTIONS=' -d '
+            fi
+            break
+        fi
+    done
+    if [ -z "$CONTAINER_BIN" ]; then
+            echo "Please install in first place <podman> or <docker>"
+            exit 1
+    fi
+
 }
 
 create_server_certs() {


### PR DESCRIPTION
This covers the case when <podman-docker.noarch> rpm is installed.
In this situation, the script was cheated, and the container manager selected was <docker> instead <podman>, making imposible to start the ARS container because wrong options selected.

Simply changing the order in the <CONTAINER_OPTS> var solves this issue.

Also i have added a check to print an error if there is no container manager installed.