### PR TITLE
Added the possibility to specify the ARS image name as environment var

### DIFF
--- a/utils/ansible-runner-service.sh
+++ b/utils/ansible-runner-service.sh
@@ -11,7 +11,6 @@ ETCDIR="/etc/ansible-runner-service"
 SERVERCERTS="$ETCDIR/certs/server"
 CLIENTCERTS="$ETCDIR/certs/client"
 RUNNERDIR="/usr/share/ansible-runner-service"
-CONTAINER_IMAGE_NAME="ansible-runner-service"
 
 CONTAINER_BIN=''
 CONTAINER_RUN_OPTIONS=''
@@ -245,6 +244,8 @@ environment_ok() {
     [ -z "$CERT_IDENTITY" ] && CERT_IDENTITY="/C=US/ST=North Carolina/L=Raleigh/O=Red Hat/OU=RunnerServer/CN=$HOST"
     [ -z "$CERT_IDENTITY_CLIENT" ] && CERT_IDENTITY_CLIENT="/C=US/ST=North Carolina/L=Raleigh/O=Red Hat/OU=RunnerClient/CN=$HOST"
     [ -z "$CERT_PASSWORD" ] && CERT_PASSWORD="ansible"
+    [ -z "$CONTAINER_IMAGE_NAME" ] && CONTAINER_IMAGE_NAME="ansible-runner-service"
+
 
     if [ "$errors" != "" ]; then
         echo "- Problems found"
@@ -273,7 +274,11 @@ usage() {
     echo -e "\t CERT_IDENTITY_CLIENT ... server certificate id (subject)"
     echo -e "\t CERT_PASSWORD ... password used to lock and access the server cert\n"
     echo "e.g."
-    echo "> CERT_PASSWORD='supersecret' ./ansible-runner-service.sh -v -s"
+    echo -e "> CERT_PASSWORD='supersecret' ./ansible-runner-service.sh -v -s\n"
+    echo -e "Ansible Runner Service container image name can be customized (<ansible-runner-service> by default) using a environment variable:\n"
+    echo -e "\t CONTAINER_IMAGE_NAME ... string used in the <pull> command to get the ARS container image\n"
+    echo "e.g."
+    echo -e "> CONTAINER_IMAGE_NAME='ansible/ansible-runner-service' ./ansible-runner-service.sh -v -s\n"
 }
 
 is_running() {


### PR DESCRIPTION
In this way we have flexibility to make possible to pull the container image from registry. 

The first container image will be in the official registry but in a "beta" folder ... and this will change in the future. 
Probably we can live with this situation using this modification. In the worst case the instructions for the final user will be:
- A Red Hat registry account will be needed to pull the ARS container image. Configure podman to use the Red Hat registry and this account.
- Configure ARS using:
> CONTAINER_IMAGE_NAME='beta/ansible-runner-service.sh' ./ansible-runner-service.sh


**Manually tested:**

```
[root@master ~]# CONTAINER_IMAGE_NAME='pepe' ./ansible-runner-service.sh
Checking environment is ready
Checking/creating directories
Checking SSL certificate configuration
Applying SELINUX container_file_t context to '/etc/ansible-runner-service'
Applying SELINUX container_file_t context to '/usr/share/ceph-ansible'
Fetching ansible runner service container. Please wait...
Trying to pull registry.redhat.io/pepe:latest...Failed
Trying to pull quay.io/pepe:latest...Failed
Trying to pull docker.io/pepe:latest...Failed
error pulling image "pepe": unable to pull pepe: 3 errors occurred:

* Error determining manifest MIME type for docker://registry.redhat.io/pepe:latest: unable to retrieve auth token: invalid username/password
* Error determining manifest MIME type for docker://quay.io/pepe:latest: Error reading manifest latest in quay.io/pepe: error parsing HTTP 404 response body: invalid character '<' looking for beginning of value: "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n<title>404 Not Found</title>\n<h1>Not Found</h1>\n<p>The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.</p>\n"
* Error determining manifest MIME type for docker://pepe:latest: Error reading manifest latest in docker.io/library/pepe: errors:
denied: requested access to the resource is denied
unauthorized: authentication required

Failed to fetch the container. Unable to continue
[root@master ~]# podman ps -a
CONTAINER ID  IMAGE  COMMAND  CREATED  STATUS  PORTS  NAMES

[root@master ~]# podman images
REPOSITORY                                            TAG                                                                IMAGE ID       CREATED       SIZE
docker.io/ceph/daemon                                 latest                                                             09209b86681e   13 days ago   910 MB
localhost/tjeyasin/ansible-runner-service-container   ceph-4.0-rhel-8-containers-candidate-34906-20190808063459-x86_64   b96067ea93c8   5 weeks ago   476 MB


[root@master ~]# CONTAINER_IMAGE_NAME='ansible-runner-service' ./new_ars.sh 
Checking environment is ready
Checking/creating directories
Checking SSL certificate configuration
Applying SELINUX container_file_t context to '/etc/ansible-runner-service'
Applying SELINUX container_file_t context to '/usr/share/ceph-ansible'
Using the ansible_runner_service container already downloaded
Starting runner-service container
Started runner-service container
Waiting for runner-service container to respond
runner-service container is available and responding to requests

[root@master ~]# podman ps -a
CONTAINER ID  IMAGE                                                                                                                 COMMAND               CREATED             STATUS                 PORTS  NAMES
bbac6e7d833d  localhost/tjeyasin/ansible-runner-service-container:ceph-4.0-rhel-8-containers-candidate-34906-20190808063459-x86_64  /usr/bin/supervis...  About a minute ago  Up About a minute ago         runner-service

```
