### PR TITLE
Replace hostname with FQDN in success message

### DIFF
--- a/utils/ansible-runner-service.sh
+++ b/utils/ansible-runner-service.sh
@@ -396,7 +396,7 @@ start_runner_service() {
             ;;
         200)
             echo "The Ansible API container (runner-service) is available and responding to requests"
-            echo -e "\nLogin to the cockpit UI at https://$(hostname):9090/cockpit-ceph-installer to start the install"
+            echo -e "\nLogin to the cockpit UI at https://$(hostname -f):9090/cockpit-ceph-installer to start the install"
             ;;
         *)
             echo "The Ansible API container (runner-service) responded with unexpected status code: $CURL_RC"


### PR DESCRIPTION
This patch tunes cockpit UI link displayed on successuful configuration of Ansible API container
'hostname' can be a short name and shortnames might not be resolvable everywhere
It would be nice if we can display FQDN to reduce confusion to user

Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>