### PR TITLE
Add hosts file to ceph-ansible for day to day operations

### DIFF
--- a/utils/ansible-runner-service.sh
+++ b/utils/ansible-runner-service.sh
@@ -441,7 +441,13 @@ manage_ansible_hosts_file() {
         else
             echo "WARNING: failed to apply the symlink, please investigate"
         fi
-
+	# Keep a copy in the ceph-ansible directory for other day to day operations
+	ln -s /usr/share/ansible-runner-service/inventory/hosts /usr/share/ceph-ansible/hosts
+        if [ $? -eq 0 ]; then
+            echo "- ansible hosts linked to ceph-ansible for other day to day operations"
+        else
+            echo "WARNING: failed to apply the symlink, please investigate"
+        fi
     fi
 }
 


### PR DESCRIPTION
Currently hosts file is availabe in /usr/share/ansible-runner-service
directory under inventory folder. This is valid for ceph 3.x
as per the documentation. Whereas in ceph 4.x it is mentioned
that the hosts file will be available at ceph-ansible directory.
So we need to keep it in ceph-ansible directory for other day to
day operation such as upgrade, add new monitor role and etc.,
This patch will provide a similink of the hosts file
to ceph-ansible directory.

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>