### PR TITLE
Remove rgw buckets data and index value

### DIFF
--- a/src/services/ansibleMap.js
+++ b/src/services/ansibleMap.js
@@ -231,12 +231,6 @@ export function rgwsVars(vars) {
     }
 
     forYML.radosgw_frontend_port = "8080";
-    forYML.rgw_override_bucket_index_max_shards = 1;
-    forYML.rgw_create_pools = {
-        "defaults.rgw.buckets.data": { "pgnum": 16 },
-        "defaults.rgw.buckets.index": { "pgnum": 32 }
-    };
-
     return forYML;
 }
 


### PR DESCRIPTION
Remove setting defaults.rgw.buckets data, index
and rgw_override_bucket_index_max_shards values
to use the default values.

See for more details: https://bugzilla.redhat.com/show_bug.cgi?id=1855148
Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>